### PR TITLE
Error and warning printings2

### DIFF
--- a/regress.py
+++ b/regress.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     if not (path_file or local_file):
         print_errors("Command \"" + command + "\" does not exist")
         debug("Terminating Program.")
-        exit()
+        sys.exit(100)
 
     # Find all input/output files
     input_files = glob.glob(os.path.join(PATH, IN + '*'))
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
     if terminate_program:
         debug("Terminating Program.")
-        exit()
+        sys.exit(101)
 
     for test, outpath in valid_pairs:
         input_file = open(test)


### PR DESCRIPTION
-Error and warning prints are now separated into two functions
-If -e is enabled Regress will check all the corresponding output files (previously it will stop after finding one missing)
-If -e is enabled Regress will only diff the files pairs if there are no mismatched pairs
(Every tab is now set to 4 spaces)